### PR TITLE
Added Event Broadcast `AfterBuildMessage`

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -4442,7 +4442,7 @@ class Module extends \Aurora\System\Module\AbstractModule
 		$oMessage = self::Decorator()->BuildMessage($oAccount, $To, $Cc, $Bcc,
 			$Subject, $IsHtml, $Text, $Attachments, $DraftInfo, $InReplyTo, $References, $Importance,
 			$Sensitivity, $SendReadingConfirmation, $Fetcher, $Alias, false, $oIdentity, $CustomHeaders);
-
+		$this->broadcastEvent('AfterBuildMessage', $oMessage);
 		if ($oMessage)
 		{
 			$mResult = $this->getMailManager()->sendMessage($oAccount, $oMessage, $Fetcher, $SentFolder, $DraftFolder, $DraftUid, $Recipients);


### PR DESCRIPTION
Adds an event called `AfterBuildMessage`.

This adds the ability to modify the message object itself before its sent rather than just the `Mail::SendMessage` before and after which just includes the arguments.

This also exposes the MessageID and all other information generated in the `BuildMessage` before the message is sent which is useful if a module wants to implement some sort of Message Logging or they want to add things such as headers into the actual Message rather than using `Mail::ExtendMessageData` after its gotten.